### PR TITLE
Enable prefix embeddings for generation

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -1,6 +1,9 @@
 import os
 import time
 from random import randint, seed
+
+import torch
+
 from nanovllm import LLM, SamplingParams
 # from vllm import LLM, SamplingParams
 
@@ -14,6 +17,9 @@ def main():
     path = os.path.expanduser("~/huggingface/Qwen3-0.6B/")
     llm = LLM(path, enforce_eager=False, max_model_len=4096)
 
+    embed_dim = llm.model_runner.model.model.embed_tokens.weight.size(1)
+    audio_embeds = [torch.randn(750, embed_dim) for _ in range(num_seqs)]
+
     prompt_token_ids = [[randint(0, 10000) for _ in range(randint(100, max_input_len))] for _ in range(num_seqs)]
     sampling_params = [SamplingParams(temperature=0.6, ignore_eos=True, max_tokens=randint(100, max_ouput_len)) for _ in range(num_seqs)]
     # uncomment the following line for vllm
@@ -21,7 +27,7 @@ def main():
 
     llm.generate(["Benchmark: "], SamplingParams())
     t = time.time()
-    llm.generate(prompt_token_ids, sampling_params, use_tqdm=False)
+    llm.generate(prompt_token_ids, sampling_params, prompt_embeds=audio_embeds, use_tqdm=False)
     t = (time.time() - t)
     total_tokens = sum(sp.max_tokens for sp in sampling_params)
     throughput = total_tokens / t

--- a/example.py
+++ b/example.py
@@ -1,12 +1,18 @@
 import os
-from nanovllm import LLM, SamplingParams
+
+import torch
 from transformers import AutoTokenizer
+
+from nanovllm import LLM, SamplingParams
 
 
 def main():
     path = os.path.expanduser("~/huggingface/Qwen3-0.6B/")
     tokenizer = AutoTokenizer.from_pretrained(path)
     llm = LLM(path, enforce_eager=True, tensor_parallel_size=1)
+
+    embed_dim = llm.model_runner.model.model.embed_tokens.weight.size(1)
+    audio_embeds = [torch.randn(750, embed_dim) for _ in range(2)]
 
     sampling_params = SamplingParams(temperature=0.6, max_tokens=256)
     prompts = [
@@ -22,7 +28,7 @@ def main():
         )
         for prompt in prompts
     ]
-    outputs = llm.generate(prompts, sampling_params)
+    outputs = llm.generate(prompts, sampling_params, prompt_embeds=audio_embeds)
 
     for prompt, output in zip(prompts, outputs):
         print("\n")

--- a/nanovllm/engine/llm_engine.py
+++ b/nanovllm/engine/llm_engine.py
@@ -39,10 +39,25 @@ class LLMEngine:
         for p in self.ps:
             p.join()
 
-    def add_request(self, prompt: str | list[int], sampling_params: SamplingParams):
+    def add_request(
+        self,
+        prompt: str | list[int],
+        sampling_params: SamplingParams,
+        prompt_embeds=None,
+    ):
         if isinstance(prompt, str):
-            prompt = self.tokenizer.encode(prompt)
-        seq = Sequence(prompt, sampling_params)
+            prompt_ids = self.tokenizer.encode(prompt)
+        else:
+            prompt_ids = prompt
+        if prompt_embeds is not None:
+            pad_id = self.tokenizer.pad_token_id or self.tokenizer.eos_token_id
+            seq_id = next(Sequence.counter)
+            dummy_ids = [-(seq_id + 1) * 1000000 - i for i in range(len(prompt_embeds))]
+            token_ids = dummy_ids + list(prompt_ids)
+        else:
+            seq_id = next(Sequence.counter)
+            token_ids = list(prompt_ids)
+        seq = Sequence(token_ids, sampling_params, prompt_embeds=prompt_embeds, seq_id=seq_id)
         self.scheduler.add(seq)
 
     def step(self):
@@ -60,14 +75,17 @@ class LLMEngine:
         self,
         prompts: list[str] | list[list[int]],
         sampling_params: SamplingParams | list[SamplingParams],
+        prompt_embeds: list | None = None,
         use_tqdm: bool = True,
     ) -> list[str]:
         if use_tqdm:
             pbar = tqdm(total=len(prompts), desc="Generating", dynamic_ncols=True)
         if not isinstance(sampling_params, list):
             sampling_params = [sampling_params] * len(prompts)
-        for prompt, sp in zip(prompts, sampling_params):
-            self.add_request(prompt, sp)
+        if prompt_embeds is None:
+            prompt_embeds = [None] * len(prompts)
+        for prompt, sp, emb in zip(prompts, sampling_params, prompt_embeds):
+            self.add_request(prompt, sp, prompt_embeds=emb)
         outputs = {}
         prefill_throughput = decode_throughput = 0.
         while not self.is_finished():

--- a/nanovllm/engine/model_runner.py
+++ b/nanovllm/engine/model_runner.py
@@ -117,6 +117,7 @@ class ModelRunner:
     def prepare_prefill(self, seqs: list[Sequence]):
         input_ids = []
         positions = []
+        embeds = []
         cu_seqlens_q = [0]
         cu_seqlens_k = [0]
         max_seqlen_q = 0
@@ -125,7 +126,8 @@ class ModelRunner:
         block_tables = None
         for seq in seqs:
             seqlen = len(seq)
-            input_ids.extend(seq[seq.num_cached_tokens:])
+            tokens = seq[seq.num_cached_tokens:]
+            input_ids.extend(tokens)
             positions.extend(list(range(seq.num_cached_tokens, seqlen)))
             seqlen_q = seqlen - seq.num_cached_tokens
             seqlen_k = seqlen
@@ -140,6 +142,20 @@ class ModelRunner:
                 else:
                     end = start + seq.last_block_num_tokens 
                 slot_mapping.extend(list(range(start, end)))
+
+            if seq.prompt_embeds is not None and seq.num_cached_tokens == 0:
+                prefix_len = seq.num_prompt_embeds
+                text_ids = tokens[prefix_len:]
+                if text_ids:
+                    text_ids = torch.tensor(text_ids, dtype=torch.int64, device="cuda", pin_memory=True).cuda(non_blocking=True)
+                    text_embeds = self.model.model.embed_tokens(text_ids)
+                    seq_embeds = torch.cat([seq.prompt_embeds.to("cuda"), text_embeds], dim=0)
+                else:
+                    seq_embeds = seq.prompt_embeds.to("cuda")
+            else:
+                ids = torch.tensor(tokens, dtype=torch.int64, device="cuda", pin_memory=True).cuda(non_blocking=True)
+                seq_embeds = self.model.model.embed_tokens(ids)
+            embeds.append(seq_embeds)
         assert len(input_ids) == len(slot_mapping)
         if cu_seqlens_k[-1] > cu_seqlens_q[-1]:    # prefix cache
             block_tables = self.prepare_block_tables(seqs)
@@ -149,7 +165,8 @@ class ModelRunner:
         cu_seqlens_k = torch.tensor(cu_seqlens_k, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         slot_mapping = torch.tensor(slot_mapping, dtype=torch.int32, pin_memory=True).cuda(non_blocking=True)
         set_context(True, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k, slot_mapping, None, block_tables)
-        return input_ids, positions
+        inputs_embeds = torch.cat(embeds, dim=0) if embeds else None
+        return input_ids, positions, inputs_embeds
 
     def prepare_decode(self, seqs: list[Sequence]):
         input_ids = []
@@ -177,7 +194,9 @@ class ModelRunner:
         return temperatures
 
     @torch.inference_mode()
-    def run_model(self, input_ids: torch.Tensor, positions: torch.Tensor, is_prefill):
+    def run_model(self, input_ids: torch.Tensor, positions: torch.Tensor, is_prefill, inputs_embeds=None):
+        if inputs_embeds is not None:
+            return self.model.compute_logits(self.model(input_ids, positions, inputs_embeds=inputs_embeds))
         if is_prefill or self.enforce_eager or input_ids.size(0) > 512:
             return self.model.compute_logits(self.model(input_ids, positions))
         else:
@@ -197,9 +216,13 @@ class ModelRunner:
             return self.model.compute_logits(graph_vars["outputs"][:bs])
 
     def run(self, seqs: list[Sequence], is_prefill: bool) -> list[int]:
-        input_ids, positions = self.prepare_prefill(seqs) if is_prefill else self.prepare_decode(seqs)
+        if is_prefill:
+            input_ids, positions, inputs_embeds = self.prepare_prefill(seqs)
+        else:
+            input_ids, positions = self.prepare_decode(seqs)
+            inputs_embeds = None
         temperatures = self.prepare_sample(seqs) if self.rank == 0 else None
-        logits = self.run_model(input_ids, positions, is_prefill)
+        logits = self.run_model(input_ids, positions, is_prefill, inputs_embeds=inputs_embeds)
         token_ids = self.sampler(logits, temperatures).tolist() if self.rank == 0 else None
         reset_context()
         return token_ids

--- a/nanovllm/engine/sequence.py
+++ b/nanovllm/engine/sequence.py
@@ -15,8 +15,14 @@ class Sequence:
     block_size = 256
     counter = count()
 
-    def __init__(self, token_ids: list[int], sampling_params: SamplingParams):
-        self.seq_id = next(Sequence.counter)
+    def __init__(
+        self,
+        token_ids: list[int],
+        sampling_params: SamplingParams,
+        prompt_embeds=None,
+        seq_id: int | None = None,
+    ):
+        self.seq_id = seq_id if seq_id is not None else next(Sequence.counter)
         self.status = SequenceStatus.WAITING
         self.token_ids = copy(token_ids)
         self.last_token = token_ids[-1]
@@ -27,6 +33,8 @@ class Sequence:
         self.temperature = sampling_params.temperature
         self.max_tokens = sampling_params.max_tokens
         self.ignore_eos = sampling_params.ignore_eos
+        self.prompt_embeds = prompt_embeds
+        self.num_prompt_embeds = 0 if prompt_embeds is None else len(prompt_embeds)
 
     def __len__(self):
         return self.num_tokens

--- a/nanovllm/models/qwen3.py
+++ b/nanovllm/models/qwen3.py
@@ -171,10 +171,14 @@ class Qwen3Model(nn.Module):
 
     def forward(
         self,
-        input_ids: torch.Tensor,
+        input_ids: torch.Tensor | None,
         positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        hidden_states = self.embed_tokens(input_ids)
+        if inputs_embeds is not None:
+            hidden_states = inputs_embeds
+        else:
+            hidden_states = self.embed_tokens(input_ids)
         residual = None
         for layer in self.layers:
             hidden_states, residual = layer(positions, hidden_states, residual)
@@ -203,10 +207,11 @@ class Qwen3ForCausalLM(nn.Module):
 
     def forward(
         self,
-        input_ids: torch.Tensor,
+        input_ids: torch.Tensor | None,
         positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        hidden_states = self.model(input_ids, positions)
+        hidden_states = self.model(input_ids, positions, inputs_embeds=inputs_embeds)
         return hidden_states
 
     def compute_logits(


### PR DESCRIPTION
## Summary
- allow sequences to carry precomputed prefix embeddings
- support prompt embeddings in `LLMEngine.generate`
- handle prefix embeddings in `ModelRunner`
- extend Qwen3 model to accept optional `inputs_embeds`
- update example scripts to show passing random audio embeddings

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68588c802f308322b3df326914cb11d9